### PR TITLE
Avoid using 'vars' when 'our' works

### DIFF
--- a/Base64.pm
+++ b/Base64.pm
@@ -1,14 +1,13 @@
 package MIME::Base64;
 
 use strict;
-use vars qw(@ISA @EXPORT @EXPORT_OK $VERSION);
 
 require Exporter;
-@ISA = qw(Exporter);
-@EXPORT = qw(encode_base64 decode_base64);
-@EXPORT_OK = qw(encode_base64url decode_base64url encoded_base64_length decoded_base64_length);
+our @ISA = qw(Exporter);
+our @EXPORT = qw(encode_base64 decode_base64);
+our @EXPORT_OK = qw(encode_base64url decode_base64url encoded_base64_length decoded_base64_length);
 
-$VERSION = '3.15';
+our $VERSION = '3.15';
 
 require XSLoader;
 XSLoader::load('MIME::Base64', $VERSION);

--- a/QuotedPrint.pm
+++ b/QuotedPrint.pm
@@ -1,13 +1,12 @@
 package MIME::QuotedPrint;
 
 use strict;
-use vars qw(@ISA @EXPORT $VERSION);
 
 require Exporter;
-@ISA = qw(Exporter);
-@EXPORT = qw(encode_qp decode_qp);
+our @ISA = qw(Exporter);
+our @EXPORT = qw(encode_qp decode_qp);
 
-$VERSION = "3.13";
+our $VERSION = "3.13";
 
 use MIME::Base64;  # will load XS version of {en,de}code_qp()
 


### PR DESCRIPTION
Anything after perl 5.6.0 will work fine with our
which is recommended over using 'use var'.

As mentioned by the vars doc https://perldoc.perl.org/vars.html
usage of 'vars' pragma is discouraged and has been superseded
by 'our' declarations available in Perl v5.6.0 or later.

Additionally using 'vars' pragma increase the memory consumption
of a program by about 700 kB for no good reason.

Similar changes are about to be merged to CORE.

References: RT-132077