### PR TITLE
Perform URL safe encoding/decoding in XS

### DIFF
--- a/lib/MIME/Base64.pm
+++ b/lib/MIME/Base64.pm
@@ -15,13 +15,6 @@ XSLoader::load('MIME::Base64', $VERSION);
 *encode = \&encode_base64;
 *decode = \&decode_base64;
 
-sub decode_base64url {
-    my $s = shift;
-    $s =~ tr[-_][+/];
-    $s .= '=' while length($s) % 4;
-    return decode_base64($s);
-}
-
 1;
 
 __END__

--- a/lib/MIME/Base64.pm
+++ b/lib/MIME/Base64.pm
@@ -15,13 +15,6 @@ XSLoader::load('MIME::Base64', $VERSION);
 *encode = \&encode_base64;
 *decode = \&decode_base64;
 
-sub encode_base64url {
-    my $e = encode_base64(shift, "");
-    $e =~ s/=+\z//;
-    $e =~ tr[+/][-_];
-    return $e;
-}
-
 sub decode_base64url {
     my $s = shift;
     $s =~ tr[-_][+/];


### PR DESCRIPTION
Resubmitting, originally at gisle/mime-base64#3

Currently the replacement of alphabet characters and trimming of the pad characters happens in pure perl. Profiling has indicated that this transformation is actually more expensive than the base64 encoding itself.

This generalises the encoding and decoding process to pad (or not pad) and use a different alphabet.