### PR TITLE
Decode mixed eol

### DIFF
--- a/t/0050-decode.t
+++ b/t/0050-decode.t
@@ -1,0 +1,48 @@
+use strict;
+use Test::More;
+
+require MIME::QuotedPrint;
+
+
+subtest test_decode_qp_rfc2045 => sub {
+    my %tests = (
+        'Hello World=0A' => "Hello World\n",
+        'Hello World=0D=0A' => "Hello World\r\n",
+        );
+
+    for my $t (sort keys %tests)
+    {
+        is MIME::QuotedPrint::decode_qp($t), $tests{$t}, "$t";
+    }
+};
+
+subtest  test_decode_qp_mixed_eols => sub {
+    my %tests = (
+        "Hello=0AWorld\r\n" => "Hello\nWorld\r\n", # implicit_nl
+        "Hello\r\nWorld=0A" => "Hello\r\nWorld\n", # implicit_explicit_nl
+        "Hello=0D=0A\r\nWorld=0A\r\n" => "Hello\r\nWorld\n", # explicit_explicit_nl
+        "Hello=0D=0A\nWorld=0A\n" => "Hello\r\nWorld\n", # explicit_explicit_nl_2
+        );
+
+    for my $t (sort keys %tests)
+    {
+        my $expected = $tests{$t};
+        my $tname    = $t;
+        my $got      = MIME::QuotedPrint::decode_qp($t);
+        $tname =~ s/\r/\\r/mg;
+        $tname =~ s/\n/\\n/mg;
+        unless( is $got, $expected, $tname )
+        {
+            ( my $enc_got = $got ) =~ s/\n/\\n/g;
+            $enc_got =~ s/\r/\\r/g;
+
+            ( my $enc_expected = $expected ) =~ s/\n/\\n/g;
+            $enc_expected =~ s/\r/\\r/g;
+            note "     got: $enc_got";
+            note "expected: $enc_expected";
+        }
+    }
+};
+
+
+done_testing();

--- a/t/quoted-print.t
+++ b/t/quoted-print.t
@@ -233,9 +233,11 @@ print "not " unless decode_qp("foo  \n\nfoo =\n\nfoo=20\n\n") eq
                                 "foo\n\nfoo \nfoo \n\n";
 $testno++; print "ok $testno\n";
 
-# Same test but with "\r\n" terminated lines
+# Same test but with "\r\n" terminated lines.  NOTE: If no encoded eol is found,
+# take the one supplied by the user!  Electronic signatures are destroyed, if we
+# enforce some "standard" eol.
 print "not " unless decode_qp("foo  \r\n\r\nfoo =\r\n\r\nfoo=20\r\n\r\n") eq
-                                "foo\n\nfoo \nfoo \n\n";
+                                "foo\r\n\r\nfoo \r\nfoo \r\n\r\n";
 $testno++; print "ok $testno\n";
 
 # Trailing whitespace
@@ -248,7 +250,7 @@ $testno++; print "ok $testno\n";
 print "not " unless decode_qp("foo = \t\x20\nbar\t\x20\n") eq "foo bar\n";
 $testno++; print "ok $testno\n";
 
-print "not " unless decode_qp("foo = \t\x20\r\nbar\t\x20\r\n") eq "foo bar\n";
+print "not " unless decode_qp("foo = \t\x20\r\nbar\t\x20\r\n") eq "foo bar\r\n";
 $testno++; print "ok $testno\n";
 
 print "not " unless decode_qp("foo = \t\x20\n") eq "foo ";
@@ -257,7 +259,7 @@ $testno++; print "ok $testno\n";
 print "not " unless decode_qp("foo = \t\x20\r\n") eq "foo ";
 $testno++; print "ok $testno\n";
 
-print "not " unless decode_qp("foo = \t\x20y\r\n") eq "foo = \t\x20y\n";
+print "not " unless decode_qp("foo = \t\x20y\r\n") eq "foo = \t\x20y\r\n";
 $testno++; print "ok $testno\n";
 
 print "not " unless decode_qp("foo =xy\n") eq "foo =xy\n";
@@ -359,4 +361,3 @@ print "not " if $] >= 5.006 && (eval 'encode_qp("XXX \x{100}")' || !$@);
 $testno++; print "ok $testno\n";
 
 }
-


### PR DESCRIPTION
MIME::QuotedPrint::qp_decode distroys the signatures of signed PDF files with mixed line endings (some encoded, some not, some "\n" some "\r\n") and is therefore not usable in professional workflows.  It does so, by enforcing some “standard” on EOLs that does not really exist (or that is badly defined and prone to misunderstandings).

The first commit on this branch adds a test to demonstrate the problem, the second one implements the fix.  The module now goes with the EOL the users supplied (and therefor intended), if in doubt (i.e. no encoded EOL was found on that line).  And, as a result, saves the electronic signatures from deterioration (which is a widely known problem).

Just for the fun of it: This is the bug report I submitted quite a while ago: https://rt.cpan.org/Public/Bug/Display.html?id=128456

Note, that the fix is installed on secure-Mail servers in production since quite a while now (in fact, I had to implement some quirky workaround to replace the buggy qp_decode: https://gitlab.com/ChipsBarrier/mime-quotedprintmscompat).  In that environment, signed content is part of about 50% of the mails going through the system.  The fix stopped the customer complaints for good.

Destroying user content is a Bug.

Outlook attaches PDF files quoted printable encoded.  That's another bug, but we cannot fix it.



